### PR TITLE
Adding Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <!--Dependency Versions-->
     <kotlin.version>1.2.61</kotlin.version>
-    <vertx-core.version>3.5.2</vertx-core.version>
+    <vertx.version>3.5.2</vertx.version>
     <dagger.version>2.9</dagger.version>
 
     <!--Test Dependency Versions-->
@@ -42,14 +42,18 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx-core.version}</version>
+      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>${vertx-core.version}</version>
+      <version>${vertx.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-config</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.google.dagger</groupId>
       <artifactId>dagger</artifactId>

--- a/src/main/kotlin/me/spradling/gift/core/api/AppComponent.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/AppComponent.kt
@@ -1,11 +1,12 @@
 package me.spradling.gift.core.api
 
 import dagger.Component
+import me.spradling.gift.core.api.modules.ConfigurationModule
 import me.spradling.gift.core.api.modules.VertxModule
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [VertxModule::class])
+@Component(modules = [VertxModule::class, ConfigurationModule::class])
 interface AppComponent {
   fun application() : Application
 }

--- a/src/main/kotlin/me/spradling/gift/core/api/Application.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/Application.kt
@@ -3,7 +3,7 @@ package me.spradling.gift.core.api
 import io.vertx.core.Vertx
 import javax.inject.Inject
 
-class Application @Inject constructor(val vertx: Vertx) {
+class Application @Inject constructor(val vertx: Vertx, val restVerticle: RestVerticle) {
 
   companion object {
     @JvmStatic
@@ -13,6 +13,6 @@ class Application @Inject constructor(val vertx: Vertx) {
   }
 
   fun launch () {
-    vertx.deployVerticle(RestVerticle())
+    vertx.deployVerticle(restVerticle)
   }
 }

--- a/src/main/kotlin/me/spradling/gift/core/api/RestVerticle.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/RestVerticle.kt
@@ -4,18 +4,21 @@ import io.vertx.core.AbstractVerticle
 import io.vertx.core.Future
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.handler.StaticHandler
+import me.spradling.gift.core.api.models.configuration.GiftCommitConfiguration
 import me.spradling.gift.core.api.routes.HealthHandler
+import javax.inject.Inject
 
-class RestVerticle : AbstractVerticle() {
+class RestVerticle @Inject constructor(val configuration: GiftCommitConfiguration) : AbstractVerticle() {
 
   override fun start(startFuture: Future<Void>) {
     val router = configureRouter()
+    var apiConfiguration = configuration.apiConfiguration
 
     vertx.createHttpServer()
         .requestHandler(router::accept)
-        .listen(8080) { result ->
+        .listen(apiConfiguration.port) { result ->
           if (result.succeeded()) {
-            print("Successfully started on port 8080")
+            print(String.format("Successfully started on port %s", apiConfiguration.port))
             startFuture.complete()
           } else {
             print("Failed to start." + result.cause())

--- a/src/main/kotlin/me/spradling/gift/core/api/VertxFuture.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/VertxFuture.kt
@@ -1,0 +1,42 @@
+package me.spradling.gift.core.api
+
+import io.vertx.core.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.CountDownLatch
+import java.time.Duration
+
+class VertxFuture {
+
+  companion object {
+    @Throws(Throwable::class)
+    fun <T> unwrap(future: Future<T>): T {
+      return unwrap(future, Duration.ZERO)
+    }
+
+    @Throws(Throwable::class)
+    fun <T> unwrap(future: Future<T>, duration: Duration): T {
+      await(future, duration)
+
+      if (future.failed()) {
+        throw future.cause()
+      }
+
+      return future.result()
+    }
+
+    @Throws(InterruptedException::class)
+    private fun <T> await(future: Future<T>, duration: Duration): Future<T> {
+      val countDownLatch = CountDownLatch(1)
+
+      future.setHandler{ r -> countDownLatch.countDown() }
+
+      if (Duration.ZERO.equals(duration)) {
+        countDownLatch.await()
+      } else {
+        countDownLatch.await(duration.toMillis(), TimeUnit.MILLISECONDS)
+      }
+
+      return future
+    }
+  }
+}

--- a/src/main/kotlin/me/spradling/gift/core/api/models/configuration/ApiConfiguration.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/models/configuration/ApiConfiguration.kt
@@ -1,0 +1,12 @@
+package me.spradling.gift.core.api.models.configuration
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class ApiConfiguration constructor(
+    @JsonProperty("host")
+    val host: String,
+    @JsonProperty("port")
+    val port: Int,
+    @JsonProperty("ssl")
+    val ssl: Boolean
+)

--- a/src/main/kotlin/me/spradling/gift/core/api/models/configuration/GiftCommitConfiguration.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/models/configuration/GiftCommitConfiguration.kt
@@ -1,0 +1,8 @@
+package me.spradling.gift.core.api.models.configuration
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class GiftCommitConfiguration constructor(
+  @JsonProperty("api")
+  val apiConfiguration : ApiConfiguration
+)

--- a/src/main/kotlin/me/spradling/gift/core/api/modules/ConfigurationModule.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/modules/ConfigurationModule.kt
@@ -1,0 +1,31 @@
+package me.spradling.gift.core.api.modules
+
+import dagger.Module
+import dagger.Provides
+import io.vertx.config.ConfigRetriever
+import io.vertx.config.ConfigStoreOptions
+import io.vertx.core.Vertx
+import io.vertx.core.json.JsonObject
+import io.vertx.kotlin.config.ConfigRetrieverOptions
+import me.spradling.gift.core.api.VertxFuture
+import me.spradling.gift.core.api.models.configuration.GiftCommitConfiguration
+import javax.inject.Singleton
+
+@Module(includes = [VertxModule::class])
+class ConfigurationModule {
+
+  @Singleton
+  @Provides
+  fun providesGiftCommitConfiguration(vertx : Vertx) : GiftCommitConfiguration {
+
+    val fileStore = ConfigStoreOptions().setType("file")
+                                        .setConfig(JsonObject(mapOf("path" to "configuration/default.json")))
+    val options = ConfigRetrieverOptions(stores = listOf(fileStore))
+    val retriever = ConfigRetriever.create(vertx, options)
+
+    val configFuture = ConfigRetriever.getConfigAsFuture(retriever)
+
+    var jsonObject = VertxFuture.unwrap(configFuture)
+    return jsonObject.mapTo(GiftCommitConfiguration::class.java)
+  }
+}

--- a/src/main/resources/configuration/default.json
+++ b/src/main/resources/configuration/default.json
@@ -1,0 +1,7 @@
+{
+  "api": {
+    "host": "gifts.spradling.me",
+    "port": 8080,
+    "ssl": true
+  }
+}


### PR DESCRIPTION
- Using new `io.vertx.vertx-config` to give the ability to specify the application configuration in `json` format.
- Adding data models to specify configuration
- Adding `VertxFuture` to be able to wait for a `Future` to complete.