### PR TITLE
Fixing Travis Tag Replacement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - openssl aes-256-cbc -K $encrypted_522778301c96_key -iv $encrypted_522778301c96_iv
   -in .build/secrets/secrets.json.enc -out .build/secrets/decrypted/secrets.json -d
 before_script:
-- if [[ $TRAVIS_TAG ]]; then mvn versions:set -DnewVersion='$TRAVIS_TAG'; fi
+- if [[ $TRAVIS_TAG ]]; then mvn versions:set -DnewVersion=$TRAVIS_TAG; fi
 script: mvn clean package
 deploy:
   provider: script


### PR DESCRIPTION
- Removing unnecessary quotes from `$TRAVIS_TAG`