### PR TITLE
Delete Account Implementation

### DIFF
--- a/src/main/kotlin/me/spradling/gift/core/api/RestVerticle.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/RestVerticle.kt
@@ -2,6 +2,7 @@ package me.spradling.gift.core.api
 
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.Future
+import io.vertx.core.http.HttpMethod
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.ext.web.handler.StaticHandler
@@ -10,6 +11,7 @@ import me.spradling.gift.core.database.GiftCommitStorageClient
 import me.spradling.gift.core.api.models.configuration.GiftCommitConfiguration
 import me.spradling.gift.core.api.routes.HealthHandler
 import me.spradling.gift.core.api.routes.v1.CreateAccountHandler
+import me.spradling.gift.core.api.routes.v1.DeleteAccountHandler
 import me.spradling.gift.core.api.routes.v1.UpdateAccountHandler
 import javax.inject.Inject
 
@@ -36,12 +38,14 @@ class RestVerticle @Inject constructor(val configuration: GiftCommitConfiguratio
   private fun configureRouter(): Router {
     val router = Router.router(vertx)
 
-    router.route().handler(BodyHandlerImpl())
+    router.route(HttpMethod.POST, "/*").handler(BodyHandlerImpl())
+    router.route(HttpMethod.PATCH, "/*").handler(BodyHandlerImpl())
     router.route("/swagger/*").handler(StaticHandler.create("swagger"))
     router.get("/health").handler(HealthHandler())
 
     router.post("/v1/accounts").handler(CreateAccountHandler(storageClient))
     router.patch("/v1/accounts/:accountId").handler(UpdateAccountHandler(storageClient))
+    router.delete("/v1/accounts/:accountId").handler(DeleteAccountHandler(storageClient))
 
     return router
   }

--- a/src/main/kotlin/me/spradling/gift/core/api/models/ApiRequest.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/models/ApiRequest.kt
@@ -2,4 +2,18 @@ package me.spradling.gift.core.api.models
 
 import io.vertx.ext.web.RoutingContext
 
-data class ApiRequest<T> constructor(val context: RoutingContext, val requestBody: T?)
+class ApiRequest<T> {
+
+  val context : RoutingContext
+  val requestBody : T?
+
+  constructor(context: RoutingContext) {
+    this.context = context
+    this.requestBody = null
+  }
+
+  constructor(context: RoutingContext, requestBody: T?) {
+    this.context = context
+    this.requestBody = requestBody
+  }
+}

--- a/src/main/kotlin/me/spradling/gift/core/api/routes/v1/DeleteAccountHandler.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/routes/v1/DeleteAccountHandler.kt
@@ -1,0 +1,22 @@
+package me.spradling.gift.core.api.routes.v1
+
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.vertx.core.Future
+import me.spradling.gift.core.api.models.ApiRequest
+import me.spradling.gift.core.api.models.responses.ApiResponse
+import me.spradling.gift.core.api.routes.GiftCommitHandler
+import me.spradling.gift.core.database.GiftCommitStorageClient
+import javax.inject.Inject
+
+class DeleteAccountHandler @Inject constructor(private val storageClient : GiftCommitStorageClient): GiftCommitHandler<Void>(Void::class.java) {
+
+  override fun handleRequest(request: ApiRequest<Void>): Future<ApiResponse> {
+    val accountId = request.context.pathParam("accountId")
+
+    return storageClient.deleteAccount(accountId).compose { _ ->
+      Future.succeededFuture(ApiResponse(HttpResponseStatus.NO_CONTENT.code()))
+    }.recover { error ->
+      Future.succeededFuture(ApiResponse.from(error))
+    }
+  }
+}

--- a/src/main/kotlin/me/spradling/gift/core/api/routes/v1/UpdateAccountHandler.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/routes/v1/UpdateAccountHandler.kt
@@ -20,7 +20,7 @@ class UpdateAccountHandler @Inject constructor(private val storageClient: GiftCo
   override fun handleRequest(request: ApiRequest<Account>): Future<ApiResponse> {
 
     val account = request.requestBody ?: return Future.succeededFuture(ApiResponse.from(ErrorDetails.INVALID_REQUEST))
-    val accountId = request.context.pathParam("accountId") ?: return Future.succeededFuture(ApiResponse.from(ErrorDetails.INVALID_REQUEST))
+    val accountId = request.context.pathParam("accountId")
 
     return storageConverter.merge(accountId, account).compose { mergedAccount ->
       storageClient.updateAccount(accountId, mergedAccount).compose { _ ->

--- a/src/main/kotlin/me/spradling/gift/core/database/aws/RDSGiftCommitStorageClient.kt
+++ b/src/main/kotlin/me/spradling/gift/core/database/aws/RDSGiftCommitStorageClient.kt
@@ -85,7 +85,10 @@ class RDSGiftCommitStorageClient @JsonCreator constructor(
   }
 
   override fun deleteAccount(accountId: String): Future<Void> {
-    TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    val deleteQuery = "DELETE FROM $accountTable WHERE accountId=$accountId"
+    connection.createStatement().executeQuery(deleteQuery)
+
+    return Future.succeededFuture()
   }
 
   override fun createItem(item: Item): Future<String> {

--- a/src/main/resources/swagger/Swagger.yaml
+++ b/src/main/resources/swagger/Swagger.yaml
@@ -111,8 +111,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-        '422':
-          $ref: '#/components/responses/UnprocessibleEntity'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/src/test/kotlin/me/spradling/gift/core/tests/unit/UnitTestBase.kt
+++ b/src/test/kotlin/me/spradling/gift/core/tests/unit/UnitTestBase.kt
@@ -2,12 +2,16 @@ package me.spradling.gift.core.tests.unit
 
 import io.vertx.core.Future
 import io.vertx.core.json.Json
+import io.vertx.ext.web.RoutingContext
 import me.spradling.gift.core.api.models.Account
 import me.spradling.gift.core.api.models.errors.Error
 import me.spradling.gift.core.api.models.errors.ErrorDetails
 import me.spradling.gift.core.api.models.responses.ApiResponse
+import me.spradling.gift.core.conversion.GiftCommitStorageConverter
+import me.spradling.gift.core.database.memory.InMemoryGiftCommitStorageClient
 import me.spradling.gift.core.tests.unit.api.UpdateAccountHandlerTests
 import org.assertj.core.api.Assertions
+import org.mockito.Mockito
 import java.io.File
 
 open class UnitTestBase {
@@ -18,6 +22,10 @@ open class UnitTestBase {
     @JvmStatic
     private val InvalidFilePath = "/data/invalid"
   }
+
+  protected val mockContext = Mockito.mock(RoutingContext::class.java)!!
+  protected val inMemoryStorageClient = InMemoryGiftCommitStorageClient()
+  protected val converter = GiftCommitStorageConverter(inMemoryStorageClient)
   protected val validAccounts = hashMapOf<String, Account>()
   protected val invalidAccounts = hashMapOf<String, Account>()
 

--- a/src/test/kotlin/me/spradling/gift/core/tests/unit/api/CreateAccountHandlerTests.kt
+++ b/src/test/kotlin/me/spradling/gift/core/tests/unit/api/CreateAccountHandlerTests.kt
@@ -1,28 +1,22 @@
 package me.spradling.gift.core.tests.unit.api
 
 import io.netty.handler.codec.http.HttpResponseStatus
-import io.vertx.ext.web.RoutingContext
 import me.spradling.gift.core.api.extensions.unwrap
 import me.spradling.gift.core.api.models.ApiRequest
-import me.spradling.gift.core.api.models.errors.Error
 import me.spradling.gift.core.api.models.errors.ErrorDetails
 import me.spradling.gift.core.api.models.responses.CreatedResource
 import me.spradling.gift.core.api.routes.v1.CreateAccountHandler
-import me.spradling.gift.core.database.memory.InMemoryGiftCommitStorageClient
 import me.spradling.gift.core.tests.unit.UnitTestBase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.mockito.Mockito.mock
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("When I call `handle` on CreateAccountHandler,")
 class CreateAccountHandlerTests : UnitTestBase() {
 
-  private val mockContext = mock(RoutingContext::class.java)!!
-  private val inMemoryStorageClient = InMemoryGiftCommitStorageClient()
   private val handler = CreateAccountHandler(inMemoryStorageClient)
 
   @Nested

--- a/src/test/kotlin/me/spradling/gift/core/tests/unit/api/DeleteAccountHandlerTests.kt
+++ b/src/test/kotlin/me/spradling/gift/core/tests/unit/api/DeleteAccountHandlerTests.kt
@@ -1,0 +1,82 @@
+package me.spradling.gift.core.tests.unit.api
+
+import io.netty.handler.codec.http.HttpResponseStatus
+import me.spradling.gift.core.api.extensions.unwrap
+import me.spradling.gift.core.api.models.ApiRequest
+import me.spradling.gift.core.api.models.errors.ErrorDetails
+import me.spradling.gift.core.api.routes.v1.DeleteAccountHandler
+import me.spradling.gift.core.tests.unit.UnitTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.Mockito.`when`
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("When I call `handle` on DeleteAccountHandler,")
+class DeleteAccountHandlerTests : UnitTestBase() {
+
+  private val handler = DeleteAccountHandler(inMemoryStorageClient)
+
+  @Nested
+  @DisplayName("given a valid account id,")
+  inner class ValidAccountId {
+
+    private val dbAccount = converter.convert(validAccounts["api"]!!)
+
+    @BeforeEach
+    fun setup() {
+      inMemoryStorageClient.createAccount(dbAccount)
+      `when`(mockContext.pathParam("accountId")).thenReturn(dbAccount.accountId)
+    }
+
+    @Test
+    @DisplayName("should succeed with 204 Http Status")
+    fun succeedsWith204() {
+
+      val response = handler.handleRequest(ApiRequest(mockContext)).unwrap()
+
+      assertThat(response.statusCode).isEqualTo(HttpResponseStatus.NO_CONTENT.code())
+    }
+
+    @Test
+    @DisplayName("should succeed with no response body")
+    fun succeedsWithNoBody() {
+
+      val response = handler.handleRequest(ApiRequest(mockContext)).unwrap()
+
+      assertThat(response.body.isPresent).isEqualTo(false)
+    }
+
+  }
+
+  @Nested
+  @DisplayName("given an account id that does not exist,")
+  inner class UserDoesNotExist {
+
+    @BeforeEach
+    fun setup() {
+      `when`(mockContext.pathParam("accountId")).thenReturn("DOES NOT EXIST")
+    }
+
+    @Test
+    @DisplayName("should fail with 404 Http Status")
+    fun succeedsWith404() {
+
+      val response = handler.handleRequest(ApiRequest(mockContext)).unwrap()
+
+      assertThat(response.statusCode).isEqualTo(HttpResponseStatus.NOT_FOUND.code())
+    }
+
+    @Test
+    @DisplayName("should succeed with no response body")
+    fun failsWithNotFoundError() {
+
+      val response = handler.handleRequest(ApiRequest(mockContext)).unwrap()
+
+      verifyErrorResponse(response, ErrorDetails.RESOURCE_NOT_FOUND)
+    }
+  }
+}

--- a/src/test/kotlin/me/spradling/gift/core/tests/unit/api/UpdateAccountHandlerTests.kt
+++ b/src/test/kotlin/me/spradling/gift/core/tests/unit/api/UpdateAccountHandlerTests.kt
@@ -26,10 +26,7 @@ import java.util.concurrent.CountDownLatch
 @DisplayName("When I call `handle` on UpdateAccountHandler,")
 class UpdateAccountHandlerTests : UnitTestBase() {
 
-  private val mockContext = Mockito.mock(RoutingContext::class.java)!!
-  private val inMemoryStorageClient = InMemoryGiftCommitStorageClient()
   private val handler = UpdateAccountHandler(inMemoryStorageClient)
-  private val converter = GiftCommitStorageConverter(inMemoryStorageClient)
 
   @Nested
   @DisplayName("given a valid request,")


### PR DESCRIPTION
- Adding implementation of `DELETE /v1/accounts/{accountId}` to be able to delete an account
- Adding unit tests to verify functionality
- Modifying routing of `BodyHandlerImpl` to avoid http methods that don't have bodies.