### PR TITLE
Create Item Implementation

### DIFF
--- a/src/main/kotlin/me/spradling/gift/core/api/RestVerticle.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/RestVerticle.kt
@@ -4,15 +4,15 @@ import io.vertx.core.AbstractVerticle
 import io.vertx.core.Future
 import io.vertx.core.http.HttpMethod
 import io.vertx.ext.web.Router
-import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.ext.web.handler.StaticHandler
 import io.vertx.ext.web.handler.impl.BodyHandlerImpl
-import me.spradling.gift.core.database.GiftCommitStorageClient
 import me.spradling.gift.core.api.models.configuration.GiftCommitConfiguration
 import me.spradling.gift.core.api.routes.HealthHandler
 import me.spradling.gift.core.api.routes.v1.CreateAccountHandler
 import me.spradling.gift.core.api.routes.v1.DeleteAccountHandler
 import me.spradling.gift.core.api.routes.v1.UpdateAccountHandler
+import me.spradling.gift.core.api.routes.v1.item.CreateItemHandler
+import me.spradling.gift.core.database.GiftCommitStorageClient
 import javax.inject.Inject
 
 class RestVerticle @Inject constructor(val configuration: GiftCommitConfiguration,
@@ -46,6 +46,8 @@ class RestVerticle @Inject constructor(val configuration: GiftCommitConfiguratio
     router.post("/v1/accounts").handler(CreateAccountHandler(storageClient))
     router.patch("/v1/accounts/:accountId").handler(UpdateAccountHandler(storageClient))
     router.delete("/v1/accounts/:accountId").handler(DeleteAccountHandler(storageClient))
+
+    router.post("/v1/items").handler(CreateItemHandler(storageClient))
 
     return router
   }

--- a/src/main/kotlin/me/spradling/gift/core/api/routes/v1/item/CreateItemHandler.kt
+++ b/src/main/kotlin/me/spradling/gift/core/api/routes/v1/item/CreateItemHandler.kt
@@ -1,0 +1,41 @@
+package me.spradling.gift.core.api.routes.v1.item
+
+import io.vertx.core.Future
+import me.spradling.gift.core.api.models.ApiRequest
+import me.spradling.gift.core.api.models.Item
+import me.spradling.gift.core.api.models.errors.ErrorDetails
+import me.spradling.gift.core.api.models.responses.ApiResponse
+import me.spradling.gift.core.api.models.responses.CreatedResourceResponse
+import me.spradling.gift.core.api.routes.GiftCommitHandler
+import me.spradling.gift.core.conversion.GiftCommitStorageConverter
+import me.spradling.gift.core.database.GiftCommitStorageClient
+import javax.inject.Inject
+
+class CreateItemHandler @Inject constructor(private val storageClient: GiftCommitStorageClient) : GiftCommitHandler<Item>(Item::class.java) {
+
+  private val storageConverter = GiftCommitStorageConverter(storageClient)
+
+  override fun handleRequest(request: ApiRequest<Item>): Future<ApiResponse> {
+    if (request.requestBody.isInvalid()) {
+      return Future.succeededFuture(ApiResponse.from(ErrorDetails.INVALID_REQUEST))
+    }
+
+    val item = request.requestBody!!
+
+    return storageClient.createItem(storageConverter.convert(item)).compose { id ->
+      Future.succeededFuture<ApiResponse>(CreatedResourceResponse(id))
+    }
+  }
+
+  fun Item?.isInvalid() : Boolean {
+    return try {
+      checkNotNull(this?.name)
+      checkNotNull(this?.price)
+      checkNotNull(this?.event)
+      false
+    } catch(ex : IllegalStateException) {
+      true
+    }
+  }
+}
+

--- a/src/main/kotlin/me/spradling/gift/core/conversion/GiftCommitStorageConverter.kt
+++ b/src/main/kotlin/me/spradling/gift/core/conversion/GiftCommitStorageConverter.kt
@@ -3,6 +3,7 @@ package me.spradling.gift.core.conversion
 import io.vertx.core.Future
 import me.spradling.gift.core.database.GiftCommitStorageClient
 import me.spradling.gift.core.database.models.Account
+import me.spradling.gift.core.database.models.Item
 import java.util.UUID
 import javax.inject.Inject
 
@@ -17,6 +18,17 @@ class GiftCommitStorageConverter @Inject constructor(private val storageClient: 
                    account.password!!)
   }
 
+  fun convert(item: me.spradling.gift.core.api.models.Item): Item {
+    return Item(UUID.randomUUID().toString(),
+                "123",
+                item.event!!,
+                item.claimed ?: false,
+                item.name!!,
+                item.url,
+                item.price!!,
+                item.notes)
+  }
+
   fun merge(accountId: String, account: me.spradling.gift.core.api.models.Account): Future<Account> {
     return storageClient.getAccount(accountId).compose { existingAccount ->
       Future.succeededFuture(Account(accountId,
@@ -25,6 +37,19 @@ class GiftCommitStorageConverter @Inject constructor(private val storageClient: 
                                     account.lastName ?: existingAccount.lastName,
                                     account.email ?: existingAccount.email,
                                     account.password ?: existingAccount.password))
+    }
+  }
+
+  fun merge(itemId: String, item: me.spradling.gift.core.api.models.Item): Future<Item> {
+    return storageClient.getItem(itemId).compose { existingItem ->
+      Future.succeededFuture(Item(itemId,
+                                  "123",
+                                  item.event ?: existingItem.event,
+                                  item.claimed ?: existingItem.claimed,
+                                  item.name ?: existingItem.name,
+                                  item.url ?: existingItem.url,
+                                  item.price ?: existingItem.price,
+                                  item.notes ?: existingItem.notes))
     }
   }
 }

--- a/src/main/kotlin/me/spradling/gift/core/database/aws/RDSGiftCommitStorageClient.kt
+++ b/src/main/kotlin/me/spradling/gift/core/database/aws/RDSGiftCommitStorageClient.kt
@@ -92,7 +92,18 @@ class RDSGiftCommitStorageClient @JsonCreator constructor(
   }
 
   override fun createItem(item: Item): Future<String> {
-    TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    val createQuery = "INSERT INTO $itemTable VALUES (${item.itemId}," +
+                                                     "${item.accountId}," +
+                                                     "${item.event}," +
+                                                     "${item.claimed}," +
+                                                     "${item.name}," +
+                                                     "${item.url}," +
+                                                     "${item.price}," +
+                                                     "${item.notes})"
+
+    connection.createStatement().executeQuery(createQuery)
+
+    return Future.succeededFuture(item.itemId)
   }
 
   override fun getItem(itemId: String): Future<Item> {

--- a/src/main/kotlin/me/spradling/gift/core/database/models/Item.kt
+++ b/src/main/kotlin/me/spradling/gift/core/database/models/Item.kt
@@ -6,7 +6,7 @@ data class Item constructor(
     val event: String,
     val claimed: Boolean,
     val name: String,
-    val url: String,
+    val url: String?,
     val price: Double,
-    val notes: String
+    val notes: String?
 )

--- a/src/test/kotlin/me/spradling/gift/core/tests/unit/UnitTestBase.kt
+++ b/src/test/kotlin/me/spradling/gift/core/tests/unit/UnitTestBase.kt
@@ -4,6 +4,7 @@ import io.vertx.core.Future
 import io.vertx.core.json.Json
 import io.vertx.ext.web.RoutingContext
 import me.spradling.gift.core.api.models.Account
+import me.spradling.gift.core.api.models.Item
 import me.spradling.gift.core.api.models.errors.Error
 import me.spradling.gift.core.api.models.errors.ErrorDetails
 import me.spradling.gift.core.api.models.responses.ApiResponse
@@ -28,6 +29,8 @@ open class UnitTestBase {
   protected val converter = GiftCommitStorageConverter(inMemoryStorageClient)
   protected val validAccounts = hashMapOf<String, Account>()
   protected val invalidAccounts = hashMapOf<String, Account>()
+  protected val validItems = hashMapOf<String, Item>()
+  protected val invalidItems = hashMapOf<String, Item>()
 
   init {
     getResourceList("$ValidFilePath/account").forEach { fileName ->
@@ -38,6 +41,14 @@ open class UnitTestBase {
     getResourceList("$InvalidFilePath/account").forEach { fileName ->
       val resource = readResource("$InvalidFilePath/account/$fileName")
       invalidAccounts[File(fileName).nameWithoutExtension] = Json.mapper.readValue(resource, Account::class.java)
+    }
+    getResourceList("$ValidFilePath/item").forEach { fileName ->
+      val resource = readResource("$ValidFilePath/item/$fileName")
+      validItems[File(fileName).nameWithoutExtension] = Json.mapper.readValue(resource, Item::class.java)
+    }
+    getResourceList("$InvalidFilePath/item").forEach { fileName ->
+      val resource = readResource("$InvalidFilePath/item/$fileName")
+      validItems[File(fileName).nameWithoutExtension] = Json.mapper.readValue(resource, Item::class.java)
     }
   }
 

--- a/src/test/kotlin/me/spradling/gift/core/tests/unit/api/item/CreateItemHandlerTests.kt
+++ b/src/test/kotlin/me/spradling/gift/core/tests/unit/api/item/CreateItemHandlerTests.kt
@@ -1,0 +1,63 @@
+package me.spradling.gift.core.tests.unit.api.item
+
+import io.netty.handler.codec.http.HttpResponseStatus
+import me.spradling.gift.core.api.extensions.unwrap
+import me.spradling.gift.core.api.models.ApiRequest
+import me.spradling.gift.core.api.models.errors.ErrorDetails
+import me.spradling.gift.core.api.models.responses.CreatedResource
+import me.spradling.gift.core.api.routes.v1.item.CreateItemHandler
+import me.spradling.gift.core.tests.unit.UnitTestBase
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("When I call `handle` on CreateItemHandler,")
+class CreateItemHandlerTests : UnitTestBase() {
+
+  private val handler = CreateItemHandler(inMemoryStorageClient)
+
+  @Nested
+  @DisplayName("given a valid request,")
+  inner class GivenValidRequest {
+
+    @Test
+    @DisplayName("request should succeed with a 201 Created")
+    fun succeedsWithCreated() {
+      val response = handler.handleRequest(ApiRequest(mockContext, validItems["api"])).unwrap()
+      Assertions.assertThat(response.statusCode).isEqualTo(HttpResponseStatus.CREATED.code())
+    }
+
+    @Test
+    @DisplayName("request should return a valid created resource response")
+    fun succeedsWithCreatedResourceResponse() {
+      val response = handler.handleRequest(ApiRequest(mockContext, validItems["api"])).unwrap()
+
+      Assertions.assertThat(response.body.get().javaClass).isEqualTo(CreatedResource::class.java)
+      val responseBody = response.body.get() as CreatedResource
+      Assertions.assertThat(responseBody.id).isNotBlank()
+    }
+  }
+
+  @Nested
+  @DisplayName("given an invalid request,")
+  inner class GivenInvalidRequest {
+
+    @Test
+    @DisplayName("request should fail with a 422 Unprocessible Entity")
+    fun failsWithUnprocessibleEntity() {
+      val response = handler.handleRequest(ApiRequest(mockContext, invalidItems["create"])).unwrap()
+      Assertions.assertThat(response.statusCode).isEqualTo(HttpResponseStatus.UNPROCESSABLE_ENTITY.code())
+    }
+
+    @Test
+    @DisplayName("request should return an Invalid Request error")
+    fun failsWithInvalidRequestError() {
+      val response = handler.handleRequest(ApiRequest(mockContext, invalidItems["create"])).unwrap()
+
+      verifyErrorResponse(response, ErrorDetails.INVALID_REQUEST)
+    }
+  }
+}

--- a/src/test/resources/data/invalid/item/create.json
+++ b/src/test/resources/data/invalid/item/create.json
@@ -1,0 +1,3 @@
+{
+  "name": "PlayStation 4"
+}

--- a/src/test/resources/data/valid/item/api.json
+++ b/src/test/resources/data/valid/item/api.json
@@ -1,0 +1,7 @@
+{
+  "event": "Christmas",
+  "name": "PlayStation 4",
+  "url": "www.amazon.com",
+  "price": 199.99,
+  "notes": "Awesome!!"
+}


### PR DESCRIPTION
- Adding implementation for `POST /v1/items` to create an item
- Adding unit tests to verify implementation

**NOTE**: Until account credential is implemented, items will be created under the `123` accountId. 